### PR TITLE
build-fix-removed-unavailable-links-with-403

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,6 @@ If you want to contribute to this list (please do), send me a pull request.
 - [9 GraphQL Security Best Practices](https://blog.escape.tech/9-graphql-security-best-practices/)
 - [Discovering GraphQL Endpoints and SQLi Vulnerabilities](https://medium.com/@localh0t/discovering-graphql-endpoints-and-sqli-vulnerabilities-5d39f26cea2e)
 - [Securing GraphQL API](https://lab.wallarm.com/securing-graphql-api/)
-- [How to secure a GraphQL API (The Complete Vulnerability Checklist)](https://leapgraph.com/graphql-api-security)
 - [Security Points to Consider Before Implementing GraphQL](https://nordicapis.com/security-points-to-consider-before-implementing-graphql/)
 
 <a name="post" />


### PR DESCRIPTION
While Checking links during build some links are not available at all 

```
Checking URLs: →✓→✓✓→✓→→✓✓→✓✓✓✓✓✓✓✓✓✓→✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓→✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→✓✓✓→✓→→✓✓✓✓✓→✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→→→✓✓✓✓✓→→✓✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→✓✓✓✓✓✓✓→✓✓x✓xxxxxx✓✓x✓✓xx✓x✓xxxxx✓xxxx✓xxxxxx✓xxxxxxxxxxxxx✓xxxxxxxxxxxxxxxx✓xxxxxxxxxxxxxx→✓xxxxx✓xxxxxx✓xxxxxxxxxx✓xxx✓xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx→→✓x→✓✓xx→xxxxx✓✓✓xxxxxxx✓x✓xxx✓xxxxx✓✓✓→✓→✓x✓→xx✓✓→✓✓✓→x→✓→✓→→✓✓→→✓✓✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓x✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓x✓✓✓→✓✓✓✓✓✓→✓✓✓✓→✓✓✓✓✓✓✓→✓→→✓xx✓✓✓✓✓✓✓✓?

Issues :-(
> Links 
  1. [L715] 403 https://www.back4app.com/graphql-database  
  2. [L814]  https://leapgraph.com/graphql-api-security Failed to open TCP connection to leapgraph.com:443 (Connection timed out - connect(2) for "leapgraph.com" port 443) 
```

So removed them

**[URL to the resource here.]**

**[Explain what this resource is all about and why it should be included here.]**
